### PR TITLE
feat: init nats jetstream

### DIFF
--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -26,10 +26,12 @@
   "dependencies": {
     "@nats-io/jetstream": "catalog:",
     "@nats-io/transport-node": "catalog:",
+    "arktype": "catalog:",
     "bullmq": "catalog:"
   },
   "devDependencies": {
     "@tix/config": "workspace:*",
+    "@tix/contracts": "workspace:*",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "pino": "catalog:",

--- a/packages/messaging/src/jetstream.test.ts
+++ b/packages/messaging/src/jetstream.test.ts
@@ -1,0 +1,201 @@
+import { jetstreamManager, RetentionPolicy, StorageType } from "@nats-io/jetstream";
+import { connect, type NatsConnection } from "@nats-io/transport-node";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { ticketCreatedV1 } from "@tix/contracts/tickets";
+
+import { createConsumer, createPublisher } from "./jetstream.ts";
+
+const dockerAvailable = ((): boolean => {
+  if (process.env["DOCKER_HOST"]) return true;
+  const home = process.env["HOME"] ?? "";
+  const candidates = [
+    "/var/run/docker.sock",
+    `${home}/.docker/run/docker.sock`,
+    `${home}/.colima/default/docker.sock`,
+    `${home}/.orbstack/run/docker.sock`,
+  ];
+  return candidates.some((p) => existsSync(p));
+})();
+
+let container: StartedTestContainer | undefined;
+let natsUrl: string | undefined;
+
+function requireUrl(): string {
+  if (!natsUrl) throw new Error("nats container not started");
+  return natsUrl;
+}
+
+async function connectNats(): Promise<NatsConnection> {
+  return await connect({ servers: requireUrl() });
+}
+
+async function freshStream(nc: NatsConnection, subject: string): Promise<string> {
+  const streamName = `S_${randomUUID().replace(/-/g, "")}`;
+  const manager = await jetstreamManager(nc);
+  await manager.streams.add({
+    name: streamName,
+    subjects: [subject],
+    retention: RetentionPolicy.Limits,
+    storage: StorageType.Memory,
+  });
+  return streamName;
+}
+
+beforeAll(async () => {
+  if (!dockerAvailable) return;
+  container = await new GenericContainer("nats:2.10-alpine")
+    .withCommand(["-js"])
+    .withExposedPorts(4222)
+    .start();
+  natsUrl = `nats://${container.getHost()}:${container.getMappedPort(4222)}`;
+}, 60_000);
+
+afterAll(async () => {
+  await container?.stop();
+});
+
+describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
+  it("publishes a payload that the consumer validates and hands to the handler exactly once", async () => {
+    const nc = await connectNats();
+    const subject = `tickets.created.v1.${randomUUID()}`;
+    const stream = await freshStream(nc, subject);
+    const group = `g-${randomUUID()}`;
+
+    const eventId = randomUUID();
+    const payload = {
+      ticketId: randomUUID(),
+      sellerId: randomUUID(),
+      title: "Test concert",
+      quantityTotal: 4,
+      unitPriceCents: 5000,
+      createdAt: new Date().toISOString(),
+    };
+
+    let resolveHandled!: (eventId: string) => void;
+    const handled = new Promise<string>((r) => {
+      resolveHandled = r;
+    });
+    let invocations = 0;
+
+    const consumer = await createConsumer(nc, {
+      stream,
+      subjectFilter: subject,
+      group,
+      schema: ticketCreatedV1,
+      handler: ({ eventId: id }) => {
+        invocations++;
+        resolveHandled(id);
+      },
+    });
+
+    const publisher = createPublisher(nc);
+
+    try {
+      const { ack } = await publisher.publish(subject, payload, { msgId: eventId });
+      expect(ack.stream).toBe(stream);
+
+      const observedEventId = await handled;
+      expect(observedEventId).toBe(eventId);
+
+      await new Promise((r) => setTimeout(r, 200));
+      expect(invocations).toBe(1);
+    } finally {
+      await consumer.stop();
+      await nc.close();
+    }
+  }, 20_000);
+
+  it("terminates malformed payloads without invoking the handler and without redelivering", async () => {
+    const nc = await connectNats();
+    const subject = `tickets.created.v1.${randomUUID()}`;
+    const stream = await freshStream(nc, subject);
+    const group = `g-${randomUUID()}`;
+
+    const badPayload = { ticketId: randomUUID() };
+
+    let invocations = 0;
+    const consumer = await createConsumer(nc, {
+      stream,
+      subjectFilter: subject,
+      group,
+      schema: ticketCreatedV1,
+      ackWaitMs: 500,
+      handler: () => {
+        invocations++;
+      },
+    });
+
+    const publisher = createPublisher(nc);
+
+    try {
+      await publisher.publish(subject, badPayload, { msgId: randomUUID() });
+
+      // ack_wait is 500ms; wait well past it so a non-terminated message would redeliver.
+      await new Promise((r) => setTimeout(r, 1500));
+
+      expect(invocations).toBe(0);
+    } finally {
+      await consumer.stop();
+      await nc.close();
+    }
+  }, 20_000);
+
+  it("redelivers the same event id when the handler throws mid-processing", async () => {
+    const nc = await connectNats();
+    const subject = `tickets.created.v1.${randomUUID()}`;
+    const stream = await freshStream(nc, subject);
+    const group = `g-${randomUUID()}`;
+
+    const eventId = randomUUID();
+    const payload = {
+      ticketId: randomUUID(),
+      sellerId: randomUUID(),
+      title: "Retry concert",
+      quantityTotal: 2,
+      unitPriceCents: 1000,
+      createdAt: new Date().toISOString(),
+    };
+
+    const deliveredIds: string[] = [];
+    let resolveSecond!: () => void;
+    const second = new Promise<void>((r) => {
+      resolveSecond = r;
+    });
+
+    const consumer = await createConsumer(nc, {
+      stream,
+      subjectFilter: subject,
+      group,
+      schema: ticketCreatedV1,
+      ackWaitMs: 500,
+      handler: ({ eventId: id }) => {
+        deliveredIds.push(id);
+
+        if (deliveredIds.length === 1) {
+          throw new Error("simulated crash");
+        }
+
+        resolveSecond();
+      },
+    });
+
+    const publisher = createPublisher(nc);
+
+    try {
+      await publisher.publish(subject, payload, { msgId: eventId });
+
+      await second;
+
+      expect(deliveredIds.length).toBeGreaterThanOrEqual(2);
+      expect(deliveredIds[0]).toBe(eventId);
+      expect(deliveredIds[1]).toBe(eventId);
+    } finally {
+      await consumer.stop();
+      await nc.close();
+    }
+  }, 20_000);
+});

--- a/packages/messaging/src/jetstream.test.ts
+++ b/packages/messaging/src/jetstream.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { ticketCreatedV1 } from "@tix/contracts/tickets";
 
-import { createConsumer, createPublisher } from "./jetstream.ts";
+import { createConsumer, createPublisher, type Publisher } from "./jetstream.ts";
 
 const dockerAvailable = ((): boolean => {
   if (process.env["DOCKER_HOST"]) return true;
@@ -45,6 +45,23 @@ async function freshStream(nc: NatsConnection, subject: string): Promise<string>
   return streamName;
 }
 
+type TestContext = {
+  nc: NatsConnection;
+  subject: string;
+  stream: string;
+  group: string;
+  publisher: Publisher;
+};
+
+async function setupContext(): Promise<TestContext> {
+  const nc = await connectNats();
+  const subject = `tickets.created.v1.${randomUUID()}`;
+  const stream = await freshStream(nc, subject);
+  const group = `g-${randomUUID()}`;
+  const publisher = createPublisher(nc);
+  return { nc, subject, stream, group, publisher };
+}
+
 beforeAll(async () => {
   if (!dockerAvailable) return;
   container = await new GenericContainer("nats:2.10-alpine")
@@ -60,10 +77,7 @@ afterAll(async () => {
 
 describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
   it("publishes a payload that the consumer validates and hands to the handler exactly once", async () => {
-    const nc = await connectNats();
-    const subject = `tickets.created.v1.${randomUUID()}`;
-    const stream = await freshStream(nc, subject);
-    const group = `g-${randomUUID()}`;
+    const { nc, subject, stream, group, publisher } = await setupContext();
 
     const eventId = randomUUID();
     const payload = {
@@ -92,8 +106,6 @@ describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
       },
     });
 
-    const publisher = createPublisher(nc);
-
     try {
       const { ack } = await publisher.publish(subject, payload, { msgId: eventId });
       expect(ack.stream).toBe(stream);
@@ -110,10 +122,7 @@ describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
   }, 20_000);
 
   it("terminates malformed payloads without invoking the handler and without redelivering", async () => {
-    const nc = await connectNats();
-    const subject = `tickets.created.v1.${randomUUID()}`;
-    const stream = await freshStream(nc, subject);
-    const group = `g-${randomUUID()}`;
+    const { nc, subject, stream, group, publisher } = await setupContext();
 
     const badPayload = { ticketId: randomUUID() };
 
@@ -129,8 +138,6 @@ describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
       },
     });
 
-    const publisher = createPublisher(nc);
-
     try {
       await publisher.publish(subject, badPayload, { msgId: randomUUID() });
 
@@ -144,11 +151,83 @@ describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
     }
   }, 20_000);
 
+  it("terminates messages missing the Nats-Msg-Id header without invoking the handler", async () => {
+    const { nc, subject, stream, group, publisher } = await setupContext();
+
+    const payload = {
+      ticketId: randomUUID(),
+      sellerId: randomUUID(),
+      title: "Headerless concert",
+      quantityTotal: 1,
+      unitPriceCents: 100,
+      createdAt: new Date().toISOString(),
+    };
+
+    let invocations = 0;
+    const consumer = await createConsumer(nc, {
+      stream,
+      subjectFilter: subject,
+      group,
+      schema: ticketCreatedV1,
+      ackWaitMs: 500,
+      handler: () => {
+        invocations++;
+      },
+    });
+
+    try {
+      await publisher.publish(subject, payload);
+
+      await new Promise((r) => setTimeout(r, 1500));
+
+      expect(invocations).toBe(0);
+    } finally {
+      await consumer.stop();
+      await nc.close();
+    }
+  }, 20_000);
+
+  it("does not redeliver when the handler acks early and then throws", async () => {
+    const { nc, subject, stream, group, publisher } = await setupContext();
+
+    const eventId = randomUUID();
+    const payload = {
+      ticketId: randomUUID(),
+      sellerId: randomUUID(),
+      title: "Early-ack concert",
+      quantityTotal: 1,
+      unitPriceCents: 100,
+      createdAt: new Date().toISOString(),
+    };
+
+    let invocations = 0;
+    const consumer = await createConsumer(nc, {
+      stream,
+      subjectFilter: subject,
+      group,
+      schema: ticketCreatedV1,
+      ackWaitMs: 500,
+      handler: ({ ack }) => {
+        invocations++;
+        ack();
+        throw new Error("post-ack failure");
+      },
+    });
+
+    try {
+      await publisher.publish(subject, payload, { msgId: eventId });
+
+      await new Promise((r) => setTimeout(r, 1500));
+
+      expect(invocations).toBe(1);
+    } finally {
+      await consumer.stop();
+      await nc.close();
+    }
+  }, 20_000);
+
   it("redelivers the same event id when the handler throws mid-processing", async () => {
-    const nc = await connectNats();
-    const subject = `tickets.created.v1.${randomUUID()}`;
-    const stream = await freshStream(nc, subject);
-    const group = `g-${randomUUID()}`;
+    const { nc, subject, stream, group, publisher } = await setupContext();
 
     const eventId = randomUUID();
     const payload = {
@@ -182,8 +261,6 @@ describe.skipIf(!dockerAvailable)("@tix/messaging/jetstream", () => {
         resolveSecond();
       },
     });
-
-    const publisher = createPublisher(nc);
 
     try {
       await publisher.publish(subject, payload, { msgId: eventId });

--- a/packages/messaging/src/jetstream.ts
+++ b/packages/messaging/src/jetstream.ts
@@ -1,1 +1,202 @@
-export const version: string = "0.0.0";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  jetstream,
+  JetStreamApiCodes,
+  JetStreamApiError,
+  jetstreamManager,
+  ReplayPolicy,
+} from "@nats-io/jetstream";
+import type { JsMsg, PubAck } from "@nats-io/jetstream";
+import type { NatsConnection } from "@nats-io/transport-node";
+import { ArkErrors, type Type } from "arktype";
+import type { Logger } from "pino";
+
+const MSG_ID_HEADER = "Nats-Msg-Id";
+
+export type PublishOptions = {
+  msgId?: string;
+};
+
+export type Publisher = {
+  publish: (
+    subject: string,
+    payload: unknown,
+    options?: PublishOptions,
+  ) => Promise<{ ack: PubAck }>;
+};
+
+export type PublisherOptions = {
+  logger?: Logger;
+};
+
+export function createPublisher(
+  natsConnection: NatsConnection,
+  options: PublisherOptions = {},
+): Publisher {
+  const js = jetstream(natsConnection);
+  const log = options.logger;
+  const encoder = new TextEncoder();
+
+  return {
+    publish: async (subject, payload, opts) => {
+      const data = encoder.encode(JSON.stringify(payload));
+      const pubOpts = opts?.msgId === undefined ? undefined : { msgID: opts.msgId };
+      const ack = await js.publish(subject, data, pubOpts);
+
+      log?.info(
+        { subject, msgId: opts?.msgId, stream: ack.stream, seq: ack.seq, duplicate: ack.duplicate },
+        "event published",
+      );
+
+      return { ack };
+    },
+  };
+}
+
+export type ConsumerHandlerArgs<Payload> = {
+  subject: string;
+  payload: Payload;
+  eventId: string;
+  ack: () => void;
+};
+
+export type ConsumerHandler<Payload> = (args: ConsumerHandlerArgs<Payload>) => Promise<void> | void;
+
+export type ConsumerOptions<Payload> = {
+  stream: string;
+  subjectFilter: string;
+  group: string;
+  schema: Type<Payload>;
+  handler: ConsumerHandler<Payload>;
+  logger?: Logger;
+  ackWaitMs?: number;
+};
+
+export type RunningConsumer = {
+  stop: () => Promise<void>;
+};
+
+export async function createConsumer<Payload>(
+  natsConnection: NatsConnection,
+  options: ConsumerOptions<Payload>,
+): Promise<RunningConsumer> {
+  const { stream, subjectFilter, group, schema, handler, logger, ackWaitMs } = options;
+  const log = logger?.child({ stream, group, subjectFilter });
+
+  const manager = await jetstreamManager(natsConnection);
+  await ensureConsumer(manager, { stream, subjectFilter, group, ackWaitMs });
+
+  const js = jetstream(natsConnection);
+  const consumer = await js.consumers.get(stream, group);
+  const messages = await consumer.consume();
+
+  const decoder = new TextDecoder();
+
+  const loop = (async () => {
+    for await (const msg of messages) {
+      await processMessage(msg, { schema, handler, decoder, log });
+    }
+  })();
+
+  loop.catch((err: unknown) => {
+    log?.error({ err }, "consumer loop terminated unexpectedly");
+  });
+
+  return {
+    stop: async () => {
+      await messages.close();
+
+      try {
+        await loop;
+      } catch {
+        // loop errors are already logged above
+      }
+    },
+  };
+}
+
+type EnsureConsumerArgs = {
+  stream: string;
+  subjectFilter: string;
+  group: string;
+  ackWaitMs: number | undefined;
+};
+
+async function ensureConsumer(
+  manager: Awaited<ReturnType<typeof jetstreamManager>>,
+  { stream, subjectFilter, group, ackWaitMs }: EnsureConsumerArgs,
+): Promise<void> {
+  try {
+    await manager.consumers.info(stream, group);
+    return;
+  } catch (err) {
+    if (!isConsumerNotFound(err)) throw err;
+  }
+
+  await manager.consumers.add(stream, {
+    durable_name: group,
+    filter_subject: subjectFilter,
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+    replay_policy: ReplayPolicy.Instant,
+    ...(ackWaitMs === undefined ? {} : { ack_wait: ackWaitMs * 1_000_000 }),
+  });
+}
+
+type ProcessMessageArgs<Payload> = {
+  schema: Type<Payload>;
+  handler: ConsumerHandler<Payload>;
+  decoder: TextDecoder;
+  log: Logger | undefined;
+};
+
+async function processMessage<Payload>(
+  msg: JsMsg,
+  { schema, handler, decoder, log }: ProcessMessageArgs<Payload>,
+): Promise<void> {
+  const subject = msg.subject;
+  const eventId = msg.headers?.get(MSG_ID_HEADER) ?? "";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoder.decode(msg.data));
+  } catch (err) {
+    log?.error({ eventId, subject, err }, "event payload is not valid JSON; terminating");
+    msg.term("invalid json");
+    return;
+  }
+
+  const validated = schema(parsed);
+  if (validated instanceof ArkErrors) {
+    log?.error(
+      { eventId, subject, summary: validated.summary },
+      "event payload failed schema validation; terminating",
+    );
+    msg.term("schema validation failed");
+    return;
+  }
+
+  let didAck = false;
+  const ack = (): void => {
+    if (didAck) return;
+    didAck = true;
+    msg.ack();
+  };
+
+  try {
+    await handler({ subject, payload: validated as Payload, eventId, ack });
+    ack();
+    log?.info({ eventId, subject, redelivered: msg.redelivered }, "event handled");
+  } catch (err) {
+    log?.error(
+      { eventId, subject, err, redelivered: msg.redelivered },
+      "handler threw; nak-ing for redelivery",
+    );
+    msg.nak();
+  }
+}
+
+function isConsumerNotFound(err: unknown): boolean {
+  return err instanceof JetStreamApiError && err.code === JetStreamApiCodes.ConsumerNotFound;
+}

--- a/packages/messaging/src/jetstream.ts
+++ b/packages/messaging/src/jetstream.ts
@@ -10,9 +10,11 @@ import {
 import type { JsMsg, PubAck } from "@nats-io/jetstream";
 import type { NatsConnection } from "@nats-io/transport-node";
 import { ArkErrors, type Type } from "arktype";
-import type { Logger } from "pino";
+import { pino, type Logger } from "pino";
 
 const MSG_ID_HEADER = "Nats-Msg-Id";
+
+const fallbackLogger: Logger = pino({ level: "warn" });
 
 export type PublishOptions = {
   msgId?: string;
@@ -35,7 +37,7 @@ export function createPublisher(
   options: PublisherOptions = {},
 ): Publisher {
   const js = jetstream(natsConnection);
-  const log = options.logger;
+  const log = options.logger ?? fallbackLogger;
   const encoder = new TextEncoder();
 
   return {
@@ -44,7 +46,7 @@ export function createPublisher(
       const pubOpts = opts?.msgId === undefined ? undefined : { msgID: opts.msgId };
       const ack = await js.publish(subject, data, pubOpts);
 
-      log?.info(
+      log.info(
         { subject, msgId: opts?.msgId, stream: ack.stream, seq: ack.seq, duplicate: ack.duplicate },
         "event published",
       );
@@ -82,7 +84,7 @@ export async function createConsumer<Payload>(
   options: ConsumerOptions<Payload>,
 ): Promise<RunningConsumer> {
   const { stream, subjectFilter, group, schema, handler, logger, ackWaitMs } = options;
-  const log = logger?.child({ stream, group, subjectFilter });
+  const log = (logger ?? fallbackLogger).child({ stream, group, subjectFilter });
 
   const manager = await jetstreamManager(natsConnection);
   await ensureConsumer(manager, { stream, subjectFilter, group, ackWaitMs });
@@ -100,7 +102,7 @@ export async function createConsumer<Payload>(
   })();
 
   loop.catch((err: unknown) => {
-    log?.error({ err }, "consumer loop terminated unexpectedly");
+    log.error({ err }, "consumer loop terminated unexpectedly");
   });
 
   return {
@@ -148,7 +150,7 @@ type ProcessMessageArgs<Payload> = {
   schema: Type<Payload>;
   handler: ConsumerHandler<Payload>;
   decoder: TextDecoder;
-  log: Logger | undefined;
+  log: Logger;
 };
 
 async function processMessage<Payload>(
@@ -156,20 +158,26 @@ async function processMessage<Payload>(
   { schema, handler, decoder, log }: ProcessMessageArgs<Payload>,
 ): Promise<void> {
   const subject = msg.subject;
-  const eventId = msg.headers?.get(MSG_ID_HEADER) ?? "";
+  const eventId = msg.headers?.get(MSG_ID_HEADER);
+
+  if (!eventId) {
+    log.error({ subject }, `event missing ${MSG_ID_HEADER} header; terminating`);
+    msg.term(`missing ${MSG_ID_HEADER} header`);
+    return;
+  }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(decoder.decode(msg.data));
   } catch (err) {
-    log?.error({ eventId, subject, err }, "event payload is not valid JSON; terminating");
+    log.error({ eventId, subject, err }, "event payload is not valid JSON; terminating");
     msg.term("invalid json");
     return;
   }
 
   const validated = schema(parsed);
   if (validated instanceof ArkErrors) {
-    log?.error(
+    log.error(
       { eventId, subject, summary: validated.summary },
       "event payload failed schema validation; terminating",
     );
@@ -177,23 +185,33 @@ async function processMessage<Payload>(
     return;
   }
 
-  let didAck = false;
+  let settled = false;
   const ack = (): void => {
-    if (didAck) return;
-    didAck = true;
+    if (settled) return;
+    settled = true;
     msg.ack();
   };
 
   try {
+    // arktype distills the call result to `finalizeDistillation<Payload, ...>`; cast back to Payload.
     await handler({ subject, payload: validated as Payload, eventId, ack });
     ack();
-    log?.info({ eventId, subject, redelivered: msg.redelivered }, "event handled");
+    log.info({ eventId, subject, redelivered: msg.redelivered }, "event handled");
   } catch (err) {
-    log?.error(
+    if (settled) {
+      log.error(
+        { eventId, subject, err, redelivered: msg.redelivered },
+        "handler threw after acking; not redelivering",
+      );
+      return;
+    }
+
+    settled = true;
+    msg.nak();
+    log.error(
       { eventId, subject, err, redelivered: msg.redelivered },
       "handler threw; nak-ing for redelivery",
     );
-    msg.nak();
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       '@nats-io/transport-node':
         specifier: 'catalog:'
         version: 3.4.0
+      arktype:
+        specifier: 'catalog:'
+        version: 2.2.0
       bullmq:
         specifier: 'catalog:'
         version: 5.76.10
@@ -543,6 +546,9 @@ importers:
       '@tix/config':
         specifier: workspace:*
         version: link:../config
+      '@tix/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1


### PR DESCRIPTION
Closes #6. Lands `@tix/messaging/jetstream`, the NATS JetStream wrapper used by every service that publishes or consumes domain events (parent PRD #1, ADR-0002, ADR-0004).

## Summary

- `createPublisher(natsConnection, { logger? })` → `{ publish(subject, payload, { msgId? }) }` returns `{ ack }`. JSON-encodes the payload and threads `msgId` through to JetStream's `Nats-Msg-Id` header so the dedupe window can short-circuit redundant publishes.
- `createConsumer<Payload>(natsConnection, { stream, subjectFilter, group, schema, handler, logger?, ackWaitMs? })` ensures a durable consumer (explicit ack, deliver-all, instant replay), then runs a `for await` loop that:
  - **Terminates** messages with a missing `Nats-Msg-Id` header — without an event id the inbox could never dedupe, so the message can't be safely processed.
  - **Terminates** messages that don't parse as JSON or fail arktype validation; the handler never sees them and JetStream won't redeliver.
  - Invokes the handler with `{ subject, payload, eventId, ack }`. Resolution → ack; rejection → `nak()` for redelivery. The handler may call `ack()` early; a subsequent throw is logged but does **not** nak (otherwise we'd double-settle).
- Both publisher and consumer accept an injected pino `Logger`; when none is provided the package falls back to a warn-level pino instance so consumer-loop crashes and validation failures are never silently swallowed.

## Tests (NATS testcontainer)

`packages/messaging/src/jetstream.test.ts` covers #6's acceptance criteria plus regressions for findings raised during PR review:

1. **Round-trip happy path** — a valid `tickets.created.v1` payload publishes, validates, hands to the handler exactly once with the original `eventId`.
2. **Malformed payload** — missing required field → consumer logs, terminates, handler never runs, no redelivery within `ack_wait`.
3. **Missing `Nats-Msg-Id` header** — terminates without invoking the handler (regression).
4. **Handler throws mid-processing** — same `eventId` is redelivered, asserting JetStream replay semantics.
5. **Handler acks early then throws** — no redelivery; the early ack wins and the catch path skips the nak (regression).

A `setupContext()` helper hands each test its own fresh subject + memory-backed stream + group + publisher, so cases don't share JetStream state. The suite uses a single `nats:2.10-alpine` container per file and skips via `describe.skipIf` when no Docker socket is reachable, matching the pattern from #18.

## Dep changes

- `@tix/messaging`: `arktype` → dep (used at runtime for `schema(...)`), `@tix/contracts` → devDep (test-only consumer of `ticketCreatedV1`).
- No new catalog entries; `pino` was already a peer/dev dep of this package and is now also used at runtime via the fallback logger.

## Out of scope

- Outbox / inbox helpers — those are separate issues (#9, #13) per ADR-0005. Consumers built on top of this wrapper must still wrap their handler with an inbox check before mutating state.

## Test plan

- [ ] `pnpm check` is green (verified locally; tests skip without Docker).
- [ ] With Docker running, `pnpm -F @tix/messaging test` exercises all five acceptance-criteria + regression tests against a live NATS container.
- [ ] `import { createPublisher, createConsumer } from "@tix/messaging/jetstream"` resolves to `dist/jetstream.{d.ts,js}` from a dependent workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
