### PR TITLE
feat: init first pass at auth

### DIFF
--- a/apps/auth/drizzle.config.ts
+++ b/apps/auth/drizzle.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   out: "./drizzle",
   schemaFilter: ["auth"],
   dbCredentials: {
-    url: process.env["DATABASE_URL"] ?? "postgres://localhost/placeholder",
+    get url(): string {
+      const u = process.env["DATABASE_URL"];
+      if (!u) throw new Error("DATABASE_URL is required for drizzle-kit migrate/push");
+
+      return u;
+    },
   },
 });

--- a/apps/auth/drizzle.config.ts
+++ b/apps/auth/drizzle.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/auth-schema.ts",
+  out: "./drizzle",
+  schemaFilter: ["auth"],
+  dbCredentials: {
+    url: process.env["DATABASE_URL"] ?? "postgres://localhost/placeholder",
+  },
+});

--- a/apps/auth/drizzle/0000_auth_initial.sql
+++ b/apps/auth/drizzle/0000_auth_initial.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA "auth";
+CREATE SCHEMA IF NOT EXISTS "auth";
 --> statement-breakpoint
 CREATE TABLE "auth"."account" (
 	"id" text PRIMARY KEY NOT NULL,

--- a/apps/auth/drizzle/0000_auth_initial.sql
+++ b/apps/auth/drizzle/0000_auth_initial.sql
@@ -1,0 +1,52 @@
+CREATE SCHEMA "auth";
+--> statement-breakpoint
+CREATE TABLE "auth"."account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp with time zone,
+	"refresh_token_expires_at" timestamp with time zone,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "auth"."session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "auth"."user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "auth"."verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "auth"."account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auth"."session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/auth/drizzle/meta/0000_snapshot.json
+++ b/apps/auth/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,320 @@
+{
+  "id": "1255f8ae-8087-444b-b8ed-506837d8acad",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/auth/drizzle/meta/_journal.json
+++ b/apps/auth/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1779379558355,
+      "tag": "0000_auth_initial",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -8,6 +8,8 @@
     "build": "tsdown",
     "check-types": "tsgo --noEmit",
     "dev": "tsx watch src/index.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
     "start": "node dist/index.js",
     "test": "vitest run --passWithNoTests"
   },

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@hono/node-server": "catalog:",
     "@orpc/server": "catalog:",
     "@tix/contracts": "workspace:*",
     "@tix/db-core": "workspace:*",
@@ -28,6 +29,7 @@
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "drizzle-kit": "catalog:",
+    "testcontainers": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",
     "vitest": "catalog:"

--- a/apps/auth/src/auth-app.ts
+++ b/apps/auth/src/auth-app.ts
@@ -1,0 +1,37 @@
+import { RPCHandler } from "@orpc/server/fetch";
+import { Hono } from "hono";
+import type { Logger } from "pino";
+
+import type { AuthInstance } from "./auth-instance.ts";
+import { requestLogger } from "./auth-logger.ts";
+import { createAuthRouter } from "./router.ts";
+
+const RPC_PREFIX = "/rpc";
+
+export type CreateAuthAppDeps = {
+  auth: AuthInstance;
+  logger: Logger;
+};
+
+export function createAuthApp(deps: CreateAuthAppDeps): Hono {
+  const router = createAuthRouter({ auth: deps.auth });
+  const rpc = new RPCHandler(router);
+
+  const app = new Hono();
+
+  app.use("*", requestLogger(deps.logger));
+
+  app.get("/health", (c) => c.json({ service: "auth", ok: true }));
+
+  app.all(`${RPC_PREFIX}/*`, async (c) => {
+    const { matched, response } = await rpc.handle(c.req.raw, {
+      prefix: RPC_PREFIX,
+      context: {},
+    });
+    if (matched) return response;
+
+    return c.notFound();
+  });
+
+  return app;
+}

--- a/apps/auth/src/auth-errors.ts
+++ b/apps/auth/src/auth-errors.ts
@@ -1,22 +1,5 @@
 import { ORPCError } from "@orpc/server";
-
-type ApiErrorLike = {
-  status?: string | number;
-  statusCode?: number;
-  body?: { code?: string; message?: string } | undefined;
-};
-
-function isApiError(value: unknown): value is ApiErrorLike {
-  if (typeof value !== "object" || value === null) return false;
-
-  const v = value as Record<string, unknown>;
-
-  return (
-    typeof v["statusCode"] === "number" ||
-    typeof v["status"] === "string" ||
-    typeof v["status"] === "number"
-  );
-}
+import { APIError } from "better-auth/api";
 
 const STATUS_TO_ORPC_CODE: Record<number, string> = {
   400: "BAD_REQUEST",
@@ -29,7 +12,7 @@ const STATUS_TO_ORPC_CODE: Record<number, string> = {
 };
 
 export function rethrowAsOrpc(error: unknown): never {
-  if (!isApiError(error)) {
+  if (!(error instanceof APIError)) {
     throw error;
   }
 

--- a/apps/auth/src/auth-errors.ts
+++ b/apps/auth/src/auth-errors.ts
@@ -1,0 +1,41 @@
+import { ORPCError } from "@orpc/server";
+
+type ApiErrorLike = {
+  status?: string | number;
+  statusCode?: number;
+  body?: { code?: string; message?: string } | undefined;
+};
+
+function isApiError(value: unknown): value is ApiErrorLike {
+  if (typeof value !== "object" || value === null) return false;
+
+  const v = value as Record<string, unknown>;
+
+  return (
+    typeof v["statusCode"] === "number" ||
+    typeof v["status"] === "string" ||
+    typeof v["status"] === "number"
+  );
+}
+
+const STATUS_TO_ORPC_CODE: Record<number, string> = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  409: "CONFLICT",
+  422: "UNPROCESSABLE_CONTENT",
+  429: "TOO_MANY_REQUESTS",
+};
+
+export function rethrowAsOrpc(error: unknown): never {
+  if (!isApiError(error)) {
+    throw error;
+  }
+
+  const statusCode = typeof error.statusCode === "number" ? error.statusCode : 500;
+  const code = STATUS_TO_ORPC_CODE[statusCode] ?? "INTERNAL_SERVER_ERROR";
+  const message = error.body?.message ?? "Authentication failed";
+
+  throw new ORPCError(code, { status: statusCode, message });
+}

--- a/apps/auth/src/auth-instance.ts
+++ b/apps/auth/src/auth-instance.ts
@@ -1,0 +1,26 @@
+import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { bearer } from "better-auth/plugins";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+import { authTables } from "./auth-schema.ts";
+
+export type AuthDeps = {
+  db: PostgresJsDatabase<typeof authTables>;
+  secret: string;
+  baseURL: string;
+};
+
+export type AuthInstance = ReturnType<typeof betterAuth>;
+
+export function createAuth(deps: AuthDeps): AuthInstance {
+  const options: BetterAuthOptions = {
+    secret: deps.secret,
+    baseURL: deps.baseURL,
+    database: drizzleAdapter(deps.db, { provider: "pg", schema: authTables }),
+    emailAndPassword: { enabled: true, autoSignIn: true },
+    plugins: [bearer()],
+  };
+
+  return betterAuth(options);
+}

--- a/apps/auth/src/auth-logger.ts
+++ b/apps/auth/src/auth-logger.ts
@@ -1,0 +1,31 @@
+import type { MiddlewareHandler } from "hono";
+import { pino, type Logger, type LoggerOptions } from "pino";
+
+export function createLogger(options: LoggerOptions = {}): Logger {
+  return pino({
+    level: process.env["LOG_LEVEL"] ?? "info",
+    ...options,
+  });
+}
+
+export function requestLogger(logger: Logger): MiddlewareHandler {
+  return async (c, next) => {
+    const started = Date.now();
+    const reqId = c.req.header("x-request-id") ?? crypto.randomUUID();
+    const child = logger.child({ reqId });
+
+    c.set("logger", child);
+
+    await next();
+
+    child.info(
+      {
+        method: c.req.method,
+        path: c.req.path,
+        status: c.res.status,
+        durationMs: Date.now() - started,
+      },
+      "request",
+    );
+  };
+}

--- a/apps/auth/src/auth-logger.ts
+++ b/apps/auth/src/auth-logger.ts
@@ -2,10 +2,7 @@ import type { MiddlewareHandler } from "hono";
 import { pino, type Logger, type LoggerOptions } from "pino";
 
 export function createLogger(options: LoggerOptions = {}): Logger {
-  return pino({
-    level: process.env["LOG_LEVEL"] ?? "info",
-    ...options,
-  });
+  return pino({ level: "info", ...options });
 }
 
 export function requestLogger(logger: Logger): MiddlewareHandler {
@@ -13,8 +10,6 @@ export function requestLogger(logger: Logger): MiddlewareHandler {
     const started = Date.now();
     const reqId = c.req.header("x-request-id") ?? crypto.randomUUID();
     const child = logger.child({ reqId });
-
-    c.set("logger", child);
 
     await next();
 

--- a/apps/auth/src/auth-schema.ts
+++ b/apps/auth/src/auth-schema.ts
@@ -1,0 +1,55 @@
+import { boolean, pgSchema, text, timestamp } from "drizzle-orm/pg-core";
+
+export const authSchema = pgSchema("auth");
+
+export const user = authSchema.table("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").notNull().default(false),
+  image: text("image"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const session = authSchema.table("session", {
+  id: text("id").primaryKey(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+});
+
+export const account = authSchema.table("account", {
+  id: text("id").primaryKey(),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  idToken: text("id_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
+  refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const verification = authSchema.table("verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const authTables = { user, session, account, verification };

--- a/apps/auth/src/auth.integration.test.ts
+++ b/apps/auth/src/auth.integration.test.ts
@@ -1,0 +1,174 @@
+import { createRouterClient } from "@orpc/server";
+import { eq } from "drizzle-orm";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { GenericContainer, type StartedTestContainer, Wait } from "testcontainers";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createDbClient } from "@tix/db-core/client";
+
+import { createAuth } from "./auth-instance.ts";
+import { authTables, user as userTable } from "./auth-schema.ts";
+import { createAuthRouter } from "./router.ts";
+
+const TEST_SECRET = "test-secret-do-not-use-in-prod-test-secret-do-not-use-in-prod";
+const TEST_BASE_URL = "http://localhost:4001";
+
+const migrationsFolder = fileURLToPath(new URL("../drizzle", import.meta.url));
+
+const dockerAvailable = ((): boolean => {
+  if (process.env["DOCKER_HOST"]) return true;
+
+  const home = process.env["HOME"] ?? "";
+  const candidates = [
+    "/var/run/docker.sock",
+    `${home}/.docker/run/docker.sock`,
+    `${home}/.colima/default/docker.sock`,
+    `${home}/.orbstack/run/docker.sock`,
+  ];
+
+  return candidates.some((p) => existsSync(p));
+})();
+
+let container: StartedTestContainer | undefined;
+let dbClient: ReturnType<typeof createDbClient<typeof authTables>> | undefined;
+let client: ReturnType<typeof createAuthRouterClient> | undefined;
+
+function createAuthRouterClient(deps: { db: typeof dbClient }) {
+  if (!deps.db) throw new Error("dbClient not initialized");
+
+  const auth = createAuth({ db: deps.db.db, secret: TEST_SECRET, baseURL: TEST_BASE_URL });
+  const router = createAuthRouter({ auth });
+
+  return createRouterClient(router);
+}
+
+beforeAll(async () => {
+  if (!dockerAvailable) return;
+
+  container = await new GenericContainer("postgres:16-alpine")
+    .withEnvironment({
+      POSTGRES_USER: "postgres",
+      POSTGRES_PASSWORD: "postgres",
+      POSTGRES_DB: "auth_test",
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage(/database system is ready to accept connections/, 2))
+    .withStartupTimeout(60_000)
+    .start();
+
+  const host = container.getHost();
+  const port = container.getMappedPort(5432);
+  const url = `postgres://postgres:postgres@${host}:${port}/auth_test`;
+
+  dbClient = createDbClient("auth", url, { schema: authTables });
+  await migrate(dbClient.db, { migrationsFolder });
+}, 120_000);
+
+afterAll(async () => {
+  await dbClient?.close();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  if (!dbClient) return;
+
+  await dbClient.sql`TRUNCATE TABLE auth.session, auth.account, auth.user RESTART IDENTITY CASCADE`;
+
+  client = createAuthRouterClient({ db: dbClient });
+});
+
+function getClient(): NonNullable<typeof client> {
+  if (!client) throw new Error("client not initialized");
+
+  return client;
+}
+
+function getDb(): NonNullable<typeof dbClient> {
+  if (!dbClient) throw new Error("dbClient not initialized");
+
+  return dbClient;
+}
+
+describe.skipIf(!dockerAvailable)("auth router", () => {
+  it("sign-up inserts a row in auth.user and returns a session token", async () => {
+    const result = await getClient().signUp({
+      email: "alice@example.com",
+      password: "correct-horse-battery",
+      name: "Alice",
+    });
+
+    expect(result.email).toBe("alice@example.com");
+    expect(result.userId).toMatch(/.+/);
+    expect(result.token).toMatch(/.+/);
+
+    const rows = await getDb().db.select().from(userTable).where(eq(userTable.id, result.userId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.email).toBe("alice@example.com");
+    expect(rows[0]?.name).toBe("Alice");
+  });
+
+  it("sign-in with correct password returns a session token, and getSession resolves the user", async () => {
+    await getClient().signUp({
+      email: "bob@example.com",
+      password: "correct-horse-battery",
+      name: "Bob",
+    });
+
+    const signedIn = await getClient().signIn({
+      email: "bob@example.com",
+      password: "correct-horse-battery",
+    });
+
+    expect(signedIn.token).toMatch(/.+/);
+
+    const session = await getClient().getSession({ token: signedIn.token });
+    expect(session).not.toBeNull();
+    expect(session?.user.email).toBe("bob@example.com");
+    expect(session?.user.name).toBe("Bob");
+    expect(session?.session.id).toMatch(/.+/);
+  });
+
+  it("sign-in with wrong password fails without leaking which check failed", async () => {
+    await getClient().signUp({
+      email: "carol@example.com",
+      password: "correct-horse-battery",
+      name: "Carol",
+    });
+
+    const wrongPassword = getClient().signIn({
+      email: "carol@example.com",
+      password: "wrong-password",
+    });
+    const unknownEmail = getClient().signIn({
+      email: "nobody@example.com",
+      password: "wrong-password",
+    });
+
+    await expect(wrongPassword).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Invalid email or password",
+    });
+    await expect(unknownEmail).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Invalid email or password",
+    });
+  });
+
+  it("sign-out invalidates the session: getSession returns null afterwards", async () => {
+    const signedUp = await getClient().signUp({
+      email: "dave@example.com",
+      password: "correct-horse-battery",
+      name: "Dave",
+    });
+
+    const before = await getClient().getSession({ token: signedUp.token });
+    expect(before).not.toBeNull();
+
+    await getClient().signOut({ token: signedUp.token });
+
+    const after = await getClient().getSession({ token: signedUp.token });
+    expect(after).toBeNull();
+  });
+});

--- a/apps/auth/src/auth.integration.test.ts
+++ b/apps/auth/src/auth.integration.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { GenericContainer, type StartedTestContainer, Wait } from "testcontainers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { createDbClient } from "@tix/db-core/client";
+import { createDbClient, type DbClient } from "@tix/db-core/client";
 
 import { createAuth } from "./auth-instance.ts";
 import { authTables, user as userTable } from "./auth-schema.ts";
@@ -31,18 +31,19 @@ const dockerAvailable = ((): boolean => {
   return candidates.some((p) => existsSync(p));
 })();
 
-let container: StartedTestContainer | undefined;
-let dbClient: ReturnType<typeof createDbClient<typeof authTables>> | undefined;
-let client: ReturnType<typeof createAuthRouterClient> | undefined;
+type AuthDbClient = DbClient<typeof authTables>;
+type AuthRouterClient = ReturnType<typeof buildRouterClient>;
 
-function createAuthRouterClient(deps: { db: typeof dbClient }) {
-  if (!deps.db) throw new Error("dbClient not initialized");
-
-  const auth = createAuth({ db: deps.db.db, secret: TEST_SECRET, baseURL: TEST_BASE_URL });
+function buildRouterClient(dbClient: AuthDbClient) {
+  const auth = createAuth({ db: dbClient.db, secret: TEST_SECRET, baseURL: TEST_BASE_URL });
   const router = createAuthRouter({ auth });
 
   return createRouterClient(router);
 }
+
+let container: StartedTestContainer | undefined;
+let dbClient: AuthDbClient | undefined;
+let client: AuthRouterClient | undefined;
 
 beforeAll(async () => {
   if (!dockerAvailable) return;
@@ -64,6 +65,8 @@ beforeAll(async () => {
 
   dbClient = createDbClient("auth", url, { schema: authTables });
   await migrate(dbClient.db, { migrationsFolder });
+
+  client = buildRouterClient(dbClient);
 }, 120_000);
 
 afterAll(async () => {
@@ -75,17 +78,15 @@ beforeEach(async () => {
   if (!dbClient) return;
 
   await dbClient.sql`TRUNCATE TABLE auth.session, auth.account, auth.user RESTART IDENTITY CASCADE`;
-
-  client = createAuthRouterClient({ db: dbClient });
 });
 
-function getClient(): NonNullable<typeof client> {
+function getClient(): AuthRouterClient {
   if (!client) throw new Error("client not initialized");
 
   return client;
 }
 
-function getDb(): NonNullable<typeof dbClient> {
+function getDb(): AuthDbClient {
   if (!dbClient) throw new Error("dbClient not initialized");
 
   return dbClient;

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -16,10 +16,21 @@ function requireEnv(name: string): string {
   return value;
 }
 
-async function main(): Promise<void> {
-  const logger = createLogger({ name: "auth" });
+function parsePort(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_PORT;
 
-  const port = Number(process.env["AUTH_HTTP_PORT"] ?? DEFAULT_PORT);
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+    throw new Error(`invalid AUTH_HTTP_PORT: ${raw}`);
+  }
+
+  return n;
+}
+
+async function main(): Promise<void> {
+  const logger = createLogger({ name: "auth", level: process.env["LOG_LEVEL"] ?? "info" });
+
+  const port = parsePort(process.env["AUTH_HTTP_PORT"]);
   const databaseUrl = requireEnv("DATABASE_URL");
   const secret = requireEnv("BETTER_AUTH_SECRET");
   const baseURL = process.env["AUTH_BASE_URL"] ?? `http://localhost:${port}`;
@@ -33,4 +44,7 @@ async function main(): Promise<void> {
   });
 }
 
-void main();
+main().catch((err: unknown) => {
+  createLogger({ name: "auth" }).fatal({ err }, "auth service failed to start");
+  process.exit(1);
+});

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -1,7 +1,36 @@
-import { Hono } from "hono";
+import { serve } from "@hono/node-server";
 
-const app = new Hono();
+import { createDbClient } from "@tix/db-core/client";
 
-app.get("/health", (c) => c.json({ service: "auth", ok: true }));
+import { createAuthApp } from "./auth-app.ts";
+import { createAuth } from "./auth-instance.ts";
+import { createLogger } from "./auth-logger.ts";
+import { authTables } from "./auth-schema.ts";
 
-export default app;
+const DEFAULT_PORT = 4001;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing required env var: ${name}`);
+
+  return value;
+}
+
+async function main(): Promise<void> {
+  const logger = createLogger({ name: "auth" });
+
+  const port = Number(process.env["AUTH_HTTP_PORT"] ?? DEFAULT_PORT);
+  const databaseUrl = requireEnv("DATABASE_URL");
+  const secret = requireEnv("BETTER_AUTH_SECRET");
+  const baseURL = process.env["AUTH_BASE_URL"] ?? `http://localhost:${port}`;
+
+  const { db } = createDbClient("auth", databaseUrl, { schema: authTables });
+  const auth = createAuth({ db, secret, baseURL });
+  const app = createAuthApp({ auth, logger });
+
+  serve({ fetch: app.fetch, port }, (info) => {
+    logger.info({ port: info.port }, "auth service listening");
+  });
+}
+
+void main();

--- a/apps/auth/src/router.ts
+++ b/apps/auth/src/router.ts
@@ -1,0 +1,111 @@
+import { os } from "@orpc/server";
+import { type } from "arktype";
+
+import { rethrowAsOrpc } from "./auth-errors.ts";
+import type { AuthInstance } from "./auth-instance.ts";
+
+const signUpInput = type({
+  email: "string.email",
+  password: "string >= 8",
+  name: "string >= 1",
+});
+
+const signInInput = type({
+  email: "string.email",
+  password: "string >= 1",
+});
+
+const tokenInput = type({
+  token: "string >= 1",
+});
+
+const credentialsOutput = type({
+  userId: "string",
+  email: "string.email",
+  token: "string",
+});
+
+const okOutput = type({
+  ok: "true",
+});
+
+const sessionOutput = type({
+  "+": "delete",
+  user: { id: "string", email: "string.email", name: "string" },
+  session: { id: "string", expiresAt: "string" },
+}).or("null");
+
+function bearerHeaders(token: string): Headers {
+  return new Headers({ authorization: `Bearer ${token}` });
+}
+
+export type AuthRouterDeps = {
+  auth: AuthInstance;
+};
+
+export function createAuthRouter(deps: AuthRouterDeps) {
+  const { auth } = deps;
+
+  const signUp = os
+    .input(signUpInput)
+    .output(credentialsOutput)
+    .handler(async ({ input }) => {
+      try {
+        const result = await auth.api.signUpEmail({ body: input });
+        if (result.token === null) {
+          throw new Error("sign-up did not return a session token");
+        }
+
+        return { userId: result.user.id, email: result.user.email, token: result.token };
+      } catch (error) {
+        rethrowAsOrpc(error);
+      }
+    });
+
+  const signIn = os
+    .input(signInInput)
+    .output(credentialsOutput)
+    .handler(async ({ input }) => {
+      try {
+        const result = await auth.api.signInEmail({ body: input });
+
+        return { userId: result.user.id, email: result.user.email, token: result.token };
+      } catch (error) {
+        rethrowAsOrpc(error);
+      }
+    });
+
+  const signOut = os
+    .input(tokenInput)
+    .output(okOutput)
+    .handler(async ({ input }) => {
+      try {
+        await auth.api.signOut({ headers: bearerHeaders(input.token) });
+
+        return { ok: true as const };
+      } catch (error) {
+        rethrowAsOrpc(error);
+      }
+    });
+
+  const getSession = os
+    .input(tokenInput)
+    .output(sessionOutput)
+    .handler(async ({ input }) => {
+      try {
+        const result = await auth.api.getSession({ headers: bearerHeaders(input.token) });
+        if (result === null) return null;
+
+        return {
+          user: { id: result.user.id, email: result.user.email, name: result.user.name },
+          session: { id: result.session.id, expiresAt: result.session.expiresAt.toISOString() },
+        };
+      } catch (error) {
+        rethrowAsOrpc(error);
+      }
+    });
+
+  return { signUp, signIn, signOut, getSession };
+}
+
+export type AuthRouter = ReturnType<typeof createAuthRouter>;

--- a/apps/auth/src/router.ts
+++ b/apps/auth/src/router.ts
@@ -1,4 +1,4 @@
-import { os } from "@orpc/server";
+import { ORPCError, os } from "@orpc/server";
 import { type } from "arktype";
 
 import { rethrowAsOrpc } from "./auth-errors.ts";
@@ -53,7 +53,9 @@ export function createAuthRouter(deps: AuthRouterDeps) {
       try {
         const result = await auth.api.signUpEmail({ body: input });
         if (result.token === null) {
-          throw new Error("sign-up did not return a session token");
+          throw new ORPCError("INTERNAL_SERVER_ERROR", {
+            message: "sign-up did not return a session token",
+          });
         }
 
         return { userId: result.user.id, email: result.user.email, token: result.token };
@@ -82,7 +84,7 @@ export function createAuthRouter(deps: AuthRouterDeps) {
       try {
         await auth.api.signOut({ headers: bearerHeaders(input.token) });
 
-        return { ok: true as const };
+        return { ok: true };
       } catch (error) {
         rethrowAsOrpc(error);
       }

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tix/config/tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@hono/node-server':
+      specifier: ^2.0.3
+      version: 2.0.3
     '@nats-io/jetstream':
       specifier: ^3.4.0
       version: 3.4.0
@@ -119,6 +122,9 @@ importers:
 
   apps/auth:
     dependencies:
+      '@hono/node-server':
+        specifier: 'catalog:'
+        version: 2.0.3(hono@4.12.21)
       '@orpc/server':
         specifier: 'catalog:'
         version: 1.14.3
@@ -162,6 +168,9 @@ importers:
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
+      testcontainers:
+        specifier: 'catalog:'
+        version: 11.14.0
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260515.1)(tsx@4.22.3)
@@ -1247,6 +1256,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.0.3':
+    resolution: {integrity: sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -3948,6 +3963,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.0
       yargs: 17.7.2
+
+  '@hono/node-server@2.0.3(hono@4.12.21)':
+    dependencies:
+      hono: 4.12.21
 
   '@inquirer/ansi@1.0.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   drizzle-kit: ^0.31.10
   drizzle-orm: ^0.45.2
   hono: ^4.12.21
+  "@hono/node-server": ^2.0.3
   jsdom: ^29.1.1
   nats: ^2.29.3
   "@nats-io/jetstream": ^3.4.0


### PR DESCRIPTION
Closes #7. Lands `apps/auth`, the Auth service. better-auth wired against the `auth` Postgres schema, exposing oRPC procedures over Hono (parent PRD #1).

## Summary

- **Drizzle schema** (`apps/auth/src/auth-schema.ts`) — better-auth's standard `user`, `session`, `account`, `verification` tables under `pgSchema("auth")`. Per-service migration committed at `apps/auth/drizzle/0000_auth_initial.sql`; `pnpm -F auth db:generate` / `db:migrate` scripts wrap drizzle-kit.
- **better-auth instance** (`auth-instance.ts`) — drizzle adapter, email + password only, `autoSignIn: true`, `bearer()` plugin so the oRPC procedures can carry session tokens via `Authorization: Bearer <token>` instead of cookies. No OAuth, no email verification, no 2FA (PRD scope).
- **oRPC router** (`router.ts`) — four procedures:
  - `signUp({ email, password, name })` → `{ userId, email, token }`
  - `signIn({ email, password })` → `{ userId, email, token }`
  - `signOut({ token })` → `{ ok: true }`
  - `getSession({ token })` → `{ user, session } | null`

  Input/output schemas are arktype; better-auth `APIError`s are translated to `ORPCError` via `auth-errors.ts` (status-code → oRPC code map), preserving the opaque `"Invalid email or password"` message.
- **Hono composition** (`auth-app.ts`, `index.ts`) — `RPCHandler` mounted at `/rpc/*`, plus `/health`. `serve()` from `@hono/node-server` listens on `AUTH_HTTP_PORT` (default 4001) with port validation. Structured request logging via a small pino-backed Hono middleware (`auth-logger.ts`) — `pino-http` doesn't fit Hono's middleware contract, so the spirit ("structured logs via pino") is honoured with a Hono-native implementation. Startup failures (missing env, bad DSN) are caught at the top level and logged at `fatal` before `process.exit(1)`.

## Tests (Postgres testcontainer)

`apps/auth/src/auth.integration.test.ts` covers all four acceptance criteria from #7. Drizzle migrations are applied automatically via `drizzle-orm/postgres-js/migrator` in `beforeAll`; the auth instance + router client are built once, and `beforeEach` truncates `session`, `account`, `user` between tests.

1. **Sign-up writes a row** in `auth.user` and returns a non-empty session token.
2. **Sign-in + getSession round-trip** — correct password returns a token; `getSession(token)` resolves the user.
3. **Opaque failure on wrong password** — both `wrong-password-for-known-email` and `any-password-for-unknown-email` reject with identical `code: "UNAUTHORIZED"` / `message: "Invalid email or password"`, so the caller can't distinguish the two checks.
4. **Sign-out invalidates the session** — `getSession(token)` returns `null` after `signOut`.

Suite skips via `describe.skipIf` when no Docker socket is reachable, matching #18 / #19.

## Dep changes

- Catalog: `@hono/node-server: ^2.0.3` added.
- `apps/auth`: `@hono/node-server` → dep, `testcontainers` → devDep.
- `apps/auth/tsconfig.json`: `allowImportingTsExtensions: true` (first app importing local `.ts` files at typecheck time).

## Out of scope

- Rate-limiting / brute-force protection on `signIn` — PRD says email + password only, no extras.
- Moving the procedure schemas to `@tix/contracts` — deferred until the gateway needs to call auth from another service.

## Test plan

- [ ] `pnpm check` is green (verified locally; integration tests skip without Docker).
- [ ] With Docker running, `pnpm -F auth test` exercises all four acceptance criteria against a live Postgres container.
- [ ] `pnpm -F auth dev` starts the service against the docker-compose Postgres after `DATABASE_URL` + `BETTER_AUTH_SECRET` are set and `pnpm -F auth db:migrate` has applied the schema.