### PR TITLE
feat: consume order created and cancelled events in payments

### DIFF
--- a/apps/payments/src/index.ts
+++ b/apps/payments/src/index.ts
@@ -8,7 +8,10 @@ import { createDbClient } from "@tix/db-core/client";
 import { createLogger } from "@tix/observability/logger";
 
 import { createPaymentsApp } from "./payments-app.ts";
-import { startPaymentsOrderCreatedConsumer } from "./payments-consumer.ts";
+import {
+  startPaymentsOrderCancelledConsumer,
+  startPaymentsOrderCreatedConsumer,
+} from "./payments-consumer.ts";
 import { paymentsTables } from "./payments-schema.ts";
 
 const DEFAULT_PORT = 4004;
@@ -65,6 +68,13 @@ async function main(): Promise<void> {
     logger,
   });
 
+  const orderCancelledConsumer = await startPaymentsOrderCancelledConsumer({
+    db,
+    nats,
+    stream: env.stream,
+    logger,
+  });
+
   const app = createPaymentsApp({ logger });
 
   const server = serve({ fetch: app.fetch, port: env.port }, (info) => {
@@ -80,6 +90,7 @@ async function main(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
     });
+    await orderCancelledConsumer.stop();
     await orderCreatedConsumer.stop();
     await nats.close();
     await db.close();

--- a/apps/payments/src/payments-consumer.integration.test.ts
+++ b/apps/payments/src/payments-consumer.integration.test.ts
@@ -7,14 +7,17 @@ import { fileURLToPath } from "node:url";
 import { GenericContainer, type StartedTestContainer, Wait } from "testcontainers";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { ORDER_CREATED_V1 } from "@tix/contracts/subjects";
+import { ORDER_CANCELLED_V1, ORDER_CREATED_V1 } from "@tix/contracts/subjects";
 import { createDbClient, type DbClient } from "@tix/db-core/client";
 import { createPublisher, type RunningConsumer } from "@tix/messaging/jetstream";
 import { dockerAvailable } from "@tix/test-helpers/docker-available";
 import { requireValue } from "@tix/test-helpers/require-value";
 import { waitFor } from "@tix/test-helpers/wait-for";
 
-import { startPaymentsOrderCreatedConsumer } from "./payments-consumer.ts";
+import {
+  startPaymentsOrderCancelledConsumer,
+  startPaymentsOrderCreatedConsumer,
+} from "./payments-consumer.ts";
 import {
   orderReadModel as orderReadModelTable,
   paymentsInbox as paymentsInboxTable,
@@ -30,7 +33,8 @@ let natsContainer: StartedTestContainer | undefined;
 let nats: NatsConnection | undefined;
 let paymentsDb: PaymentsDbClient | undefined;
 let streamName: string | undefined;
-let consumer: RunningConsumer | undefined;
+let createdConsumer: RunningConsumer | undefined;
+let cancelledConsumer: RunningConsumer | undefined;
 
 beforeAll(async () => {
   if (!dockerAvailable) return;
@@ -77,7 +81,7 @@ beforeEach(async () => {
   const manager = await jetstreamManager(nc);
   await manager.streams.add({
     name: streamName,
-    subjects: [ORDER_CREATED_V1],
+    subjects: [ORDER_CREATED_V1, ORDER_CANCELLED_V1],
     retention: RetentionPolicy.Limits,
     storage: StorageType.Memory,
     // Disable publish-side dedupe so the second publish actually reaches the
@@ -85,7 +89,13 @@ beforeEach(async () => {
     duplicate_window: 0,
   });
 
-  consumer = await startPaymentsOrderCreatedConsumer({
+  createdConsumer = await startPaymentsOrderCreatedConsumer({
+    db: dbRef,
+    nats: nc,
+    stream: streamName,
+  });
+
+  cancelledConsumer = await startPaymentsOrderCancelledConsumer({
     db: dbRef,
     nats: nc,
     stream: streamName,
@@ -94,8 +104,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
   if (!dockerAvailable) return;
-  await consumer?.stop();
-  consumer = undefined;
+  await cancelledConsumer?.stop();
+  cancelledConsumer = undefined;
+  await createdConsumer?.stop();
+  createdConsumer = undefined;
 
   if (nats && streamName) {
     const manager = await jetstreamManager(nats);
@@ -131,6 +143,26 @@ async function publishOrderCreated(args: PublishOrderCreatedArgs): Promise<void>
       priceCents: args.priceCents,
       expiresAt: expiresAt.toISOString(),
       createdAt: createdAt.toISOString(),
+    },
+    { msgId: args.eventId },
+  );
+}
+
+type PublishOrderCancelledArgs = {
+  orderId: string;
+  version: number;
+  eventId: string;
+};
+
+async function publishOrderCancelled(args: PublishOrderCancelledArgs): Promise<void> {
+  const publisher = createPublisher(requireValue(nats, "nats"));
+
+  await publisher.publish(
+    ORDER_CANCELLED_V1,
+    {
+      orderId: args.orderId,
+      version: args.version,
+      cancelledAt: new Date().toISOString(),
     },
     { msgId: args.eventId },
   );
@@ -190,6 +222,91 @@ describe.skipIf(!dockerAvailable)("payments consumer for order.created.v1", () =
     // Poll for stability: a (mis)processed redelivery would push either count
     // above 1. Sampling repeatedly is robust against CI scheduling jitter.
     await assertStable(countRows, { readModel: 1, inbox: 1 }, 1_500);
+  }, 30_000);
+});
+
+describe.skipIf(!dockerAvailable)("payments consumer for order.cancelled.v1", () => {
+  it("marks the read-model row cancelled when event version === local version + 1", async () => {
+    const orderId = randomUUID();
+    const buyerId = `buyer-${randomUUID()}`;
+
+    await publishOrderCreated({ orderId, buyerId, priceCents: 7_500, eventId: randomUUID() });
+    await waitFor(() => readReadModel(orderId), 3_000);
+
+    await publishOrderCancelled({ orderId, version: 2, eventId: randomUUID() });
+
+    const row = await waitFor(async () => {
+      const r = await readReadModel(orderId);
+      return r?.status === "cancelled" ? r : undefined;
+    }, 3_000);
+
+    expect(row).toMatchObject({
+      id: orderId,
+      version: 2,
+      status: "cancelled",
+    });
+  }, 30_000);
+
+  it("ignores a stale event when event version <= local version", async () => {
+    const orderId = randomUUID();
+    const buyerId = `buyer-${randomUUID()}`;
+
+    await publishOrderCreated({ orderId, buyerId, priceCents: 9_000, eventId: randomUUID() });
+    await waitFor(() => readReadModel(orderId), 3_000);
+
+    // event.version = 1 equals local version → fails the WHERE version = 0 check
+    // inside updateVersioned, so the row stays at version 1 / status "created".
+    await publishOrderCancelled({ orderId, version: 1, eventId: randomUUID() });
+
+    const projection = async () => {
+      const row = await readReadModel(orderId);
+      return { version: row?.version, status: row?.status };
+    };
+
+    await assertStable(projection, { version: 1, status: "created" }, 1_500);
+  }, 30_000);
+
+  it("dedupes a redelivered order.cancelled.v1: row updated once, single inbox entry", async () => {
+    const orderId = randomUUID();
+    const buyerId = `buyer-${randomUUID()}`;
+    const cancelEventId = randomUUID();
+
+    await publishOrderCreated({ orderId, buyerId, priceCents: 4_000, eventId: randomUUID() });
+    await waitFor(() => readReadModel(orderId), 3_000);
+
+    await publishOrderCancelled({ orderId, version: 2, eventId: cancelEventId });
+    await waitFor(async () => {
+      const r = await readReadModel(orderId);
+      return r?.status === "cancelled" ? r : undefined;
+    }, 3_000);
+
+    // Redeliver the same event. If it weren't deduped, updateVersioned would
+    // miss (local already at v2) — but we also want to assert the inbox stays
+    // at one row, which proves the dedupe guard fired before the update.
+    await publishOrderCancelled({ orderId, version: 2, eventId: cancelEventId });
+
+    const dbRef = requireValue(paymentsDb, "paymentsDb");
+    const snapshot = async () => {
+      const [readModelRows, inboxRows] = await Promise.all([
+        dbRef.db.select().from(orderReadModelTable).where(eq(orderReadModelTable.id, orderId)),
+        dbRef.db
+          .select()
+          .from(paymentsInboxTable)
+          .where(eq(paymentsInboxTable.eventId, cancelEventId)),
+      ]);
+      return {
+        readModel: readModelRows.length,
+        rowVersion: readModelRows[0]?.version,
+        rowStatus: readModelRows[0]?.status,
+        inbox: inboxRows.length,
+      };
+    };
+
+    await assertStable(
+      snapshot,
+      { readModel: 1, rowVersion: 2, rowStatus: "cancelled", inbox: 1 },
+      1_500,
+    );
   }, 30_000);
 });
 

--- a/apps/payments/src/payments-consumer.ts
+++ b/apps/payments/src/payments-consumer.ts
@@ -1,15 +1,17 @@
 import { type NatsConnection } from "@nats-io/transport-node";
 import { type Logger } from "pino";
 
-import { orderCreatedV1 } from "@tix/contracts/orders";
-import { ORDER_CREATED_V1 } from "@tix/contracts/subjects";
+import { orderCancelledV1, orderCreatedV1 } from "@tix/contracts/orders";
+import { ORDER_CANCELLED_V1, ORDER_CREATED_V1 } from "@tix/contracts/subjects";
 import { type DbClient } from "@tix/db-core/client";
 import { withInboxDedupe } from "@tix/db-core/inbox";
+import { updateVersioned } from "@tix/db-core/optimistic-version";
 import { createConsumer, type RunningConsumer } from "@tix/messaging/jetstream";
 
 import { orderReadModel, paymentsInbox, type paymentsTables } from "./payments-schema.ts";
 
 export const PAYMENTS_ORDER_CREATED_CONSUMER_GROUP = "payments-order-created";
+export const PAYMENTS_ORDER_CANCELLED_CONSUMER_GROUP = "payments-order-cancelled";
 
 export type StartPaymentsOrderCreatedConsumerArgs = {
   db: DbClient<typeof paymentsTables>;
@@ -18,6 +20,8 @@ export type StartPaymentsOrderCreatedConsumerArgs = {
   logger?: Logger;
   ackWaitMs?: number;
 };
+
+export type StartPaymentsOrderCancelledConsumerArgs = StartPaymentsOrderCreatedConsumerArgs;
 
 export async function startPaymentsOrderCreatedConsumer(
   args: StartPaymentsOrderCreatedConsumerArgs,
@@ -58,6 +62,55 @@ export async function startPaymentsOrderCreatedConsumer(
           logger?.info(
             { eventId, orderId: payload.orderId },
             "skipping duplicate order.created.v1",
+          );
+        }
+      });
+    },
+  });
+}
+
+export async function startPaymentsOrderCancelledConsumer(
+  args: StartPaymentsOrderCancelledConsumerArgs,
+): Promise<RunningConsumer> {
+  const { db, nats, stream, logger, ackWaitMs } = args;
+
+  const loggerOpt = logger === undefined ? {} : { logger };
+  const ackWaitOpt = ackWaitMs === undefined ? {} : { ackWaitMs };
+
+  return createConsumer(nats, {
+    stream,
+    subjectFilter: ORDER_CANCELLED_V1,
+    group: PAYMENTS_ORDER_CANCELLED_CONSUMER_GROUP,
+    schema: orderCancelledV1,
+    ...loggerOpt,
+    ...ackWaitOpt,
+    handler: async ({ eventId, subject, payload }) => {
+      await db.db.transaction(async (tx) => {
+        const result = await withInboxDedupe(tx, paymentsInbox, { eventId, subject }, async () => {
+          // `updateVersioned` matches WHERE version = event.version - 1 and bumps to
+          // event.version on success. That's the optimistic check: stale events
+          // (event.version <= local version) and out-of-order future events both
+          // miss the WHERE clause and become no-ops. The inbox row still commits,
+          // so a stale redelivery isn't retried forever.
+          const updated = await updateVersioned(
+            tx,
+            orderReadModel,
+            { id: payload.orderId, version: payload.version - 1 },
+            { status: "cancelled" },
+          );
+
+          if (updated.rowsAffected === 0) {
+            logger?.info(
+              { eventId, orderId: payload.orderId, eventVersion: payload.version },
+              "order.cancelled.v1 ignored (stale, future, or unknown order)",
+            );
+          }
+        });
+
+        if (result.deduped) {
+          logger?.info(
+            { eventId, orderId: payload.orderId },
+            "skipping duplicate order.cancelled.v1",
           );
         }
       });

--- a/packages/contracts/src/orders.test.ts
+++ b/packages/contracts/src/orders.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 
 import {
+  type OrderCancelledV1,
   type OrderCreatedV1,
   type OrderExpiredV1,
   type OrderReservationReleasedV1,
+  orderCancelledV1,
   orderCreatedV1,
   orderExpiredV1,
   orderReservationReleasedV1,
@@ -17,6 +19,12 @@ const goodCreated: OrderCreatedV1 = {
   priceCents: 10_000,
   expiresAt: "2026-05-20T12:15:00.000Z",
   createdAt: "2026-05-20T12:00:00.000Z",
+};
+
+const goodCancelled: OrderCancelledV1 = {
+  orderId: "33333333-3333-4333-8333-333333333333",
+  version: 2,
+  cancelledAt: "2026-05-20T12:10:00.000Z",
 };
 
 const goodExpired: OrderExpiredV1 = {
@@ -56,6 +64,35 @@ describe("orderCreatedV1", () => {
       priceCents: number;
       expiresAt: string;
       createdAt: string;
+    }>();
+  });
+});
+
+describe("orderCancelledV1", () => {
+  test("accepts a known-good payload", () => {
+    expect(() => orderCancelledV1.assert(goodCancelled)).not.toThrow();
+  });
+
+  test("rejects a payload missing a required field", () => {
+    const { version: _omitted, ...missing } = goodCancelled;
+    expect(() => orderCancelledV1.assert(missing)).toThrow(/version/);
+  });
+
+  test("rejects a payload with an extra unknown field", () => {
+    expect(() => orderCancelledV1.assert({ ...goodCancelled, leakedField: "nope" })).toThrow(
+      /leakedField/,
+    );
+  });
+
+  test("rejects a non-positive version", () => {
+    expect(() => orderCancelledV1.assert({ ...goodCancelled, version: 0 })).toThrow(/version/);
+  });
+
+  test("inferred type matches the documented payload shape", () => {
+    expectTypeOf<OrderCancelledV1>().toEqualTypeOf<{
+      orderId: string;
+      version: number;
+      cancelledAt: string;
     }>();
   });
 });

--- a/packages/contracts/src/orders.ts
+++ b/packages/contracts/src/orders.ts
@@ -13,6 +13,17 @@ export const orderCreatedV1 = type({
 
 export type OrderCreatedV1 = typeof orderCreatedV1.infer;
 
+export const orderCancelledV1 = type({
+  "+": "reject",
+  orderId: "string.uuid",
+  // post-transition version of the order row — consumers apply the cancel only
+  // when their local read-model is at `version - 1`, dropping stale redeliveries.
+  version: "number.integer >= 1",
+  cancelledAt: "string.date.iso",
+});
+
+export type OrderCancelledV1 = typeof orderCancelledV1.infer;
+
 export const orderExpiredV1 = type({
   "+": "reject",
   orderId: "string.uuid",

--- a/packages/contracts/src/subjects.test.ts
+++ b/packages/contracts/src/subjects.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import {
+  ORDER_CANCELLED_V1,
   ORDER_CREATED_V1,
   ORDER_EXPIRED_V1,
   ORDER_RESERVATION_RELEASED_V1,
@@ -11,6 +12,7 @@ import {
 test("subjects carry the documented .v1 suffix", () => {
   expect(TICKETS_CREATED_V1).toBe("tickets.created.v1");
   expect(ORDER_CREATED_V1).toBe("order.created.v1");
+  expect(ORDER_CANCELLED_V1).toBe("order.cancelled.v1");
   expect(ORDER_EXPIRED_V1).toBe("order.expired.v1");
   expect(ORDER_RESERVATION_RELEASED_V1).toBe("order.reservation_released.v1");
   expect(PAYMENT_CREATED_V1).toBe("payment.created.v1");

--- a/packages/contracts/src/subjects.ts
+++ b/packages/contracts/src/subjects.ts
@@ -1,5 +1,6 @@
 export const TICKETS_CREATED_V1 = "tickets.created.v1";
 export const ORDER_CREATED_V1 = "order.created.v1";
+export const ORDER_CANCELLED_V1 = "order.cancelled.v1";
 export const ORDER_EXPIRED_V1 = "order.expired.v1";
 export const ORDER_RESERVATION_RELEASED_V1 = "order.reservation_released.v1";
 export const PAYMENT_CREATED_V1 = "payment.created.v1";


### PR DESCRIPTION
- handle order cancelled
- handle order created

Closes: https://github.com/funkstyr/tix/issues/39